### PR TITLE
Schedule devnet-topn-two launch

### DIFF
--- a/pss-devnet/README.md
+++ b/pss-devnet/README.md
@@ -10,6 +10,8 @@
 
 ### Launch a top-N chain (`devnet-topn-one`)
 
+* Top N = 66
+
 Pre-launch tasks (before spawn time):
 * Opt-in with a validator that is not in the top-N
 
@@ -29,5 +31,20 @@ Pre-launch tasks (before spawn time):
 Post-launch tasks:
 * Opt-in
 * Opt-out
+* Set a commission rate
+* Try to get jailed after opting out
+
+### Launch a top-N chain (`devnet-topn-two`)
+
+* Top N = 80
+
+Pre-launch tasks (before spawn time):
+* Opt-in with a validator that is not in the top-N
+
+Post-launch tasks:
+* Opt-in with a validator that is not in the top-N
+* Opt-out with a validator that is not in the top-N
+* Get opted in by moving into the top N
+* Try (and fail) to opt-out with a validator that is in the top-N
 * Set a commission rate
 * Try to get jailed after opting out

--- a/pss-devnet/SCHEDULE.Md
+++ b/pss-devnet/SCHEDULE.Md
@@ -2,6 +2,8 @@
 
 | Date          | Event                                                |
 | ------------- | ---------------------------------------------------- |
+| Apr 19 2024   | `devnet-topn-two` consumer chain launches           |
+| Apr 18 2024   | `devnet-topn-two` consumer-addition proposal passes |
 | Apr 12 2024   | `devnet-optin-one` consumer chain launches           |
 | Apr 11 2024   | `devnet-optin-one` consumer-addition proposal passes |
 | Apr 5 2024    | `devnet-topn-one` consumer chain launches           |


### PR DESCRIPTION
April 18: Pass consumer-addition proposal
April 19: Launch `devnet-topn-two`